### PR TITLE
vim-patch:9.0.1279: display shows lines scrolled down erroneously

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1433,6 +1433,7 @@ local filename = {
   gnashrc = 'gnash',
   ['.gnuplot'] = 'gnuplot',
   ['go.sum'] = 'gosum',
+  ['go.work.sum'] = 'gosum',
   ['go.work'] = 'gowork',
   ['.gprc'] = 'gp',
   ['/.gnupg/gpg.conf'] = 'gpg',

--- a/src/nvim/testdir/test_move.vim
+++ b/src/nvim/testdir/test_move.vim
@@ -1,5 +1,8 @@
 " Test the ":move" command.
 
+source check.vim
+source screendump.vim
+
 func Test_move()
   enew!
   call append(0, ['line 1', 'line 2', 'line 3'])
@@ -42,5 +45,26 @@ func Test_move()
 
   %bwipeout!
 endfunc
+
+func Test_move_undo()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+      call setline(1, ['First', 'Second', 'Third', 'Fourth'])
+  END
+  call writefile(lines, 'Xtest_move_undo.vim', 'D')
+  let buf = RunVimInTerminal('-S Xtest_move_undo.vim', #{rows: 10, cols: 60, statusoff: 2})
+
+  call term_sendkeys(buf, "gg:move +1\<CR>")
+  call VerifyScreenDump(buf, 'Test_move_undo_1', {})
+
+  " here the display would show the last few lines scrolled down
+  call term_sendkeys(buf, "u")
+  call term_sendkeys(buf, ":\<Esc>")
+  call VerifyScreenDump(buf, 'Test_move_undo_2', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Display shows lines scrolled down erroneously. (Yishai Lerner)
Solution:   Do not change "wl_lnum" at index zero. (closes vim/vim#11938)

https://github.com/vim/vim/commit/61fdbfa1e3c842252b701aec12f45839ca41ece5

Co-authored-by: Bram Moolenaar <Bram@vim.org>
